### PR TITLE
fix(staking): change label to reflect purpose of input

### DIFF
--- a/views/dialogs/stake_token_enable.html
+++ b/views/dialogs/stake_token_enable.html
@@ -23,7 +23,7 @@
       <p class="text-small">Number of transactions that an unstake will be divided in (between 1 and 365 days)</p>
       <div class="input-group justify-content-center align-items-center mb-4">
         <input type="text" placeholder="0" id="numberTransactions">
-        <div class="input-group-append">days</div>
+        <div class="input-group-append">transactions</div>
         <div class="invalid-tooltip">
           Please enter an amount greater than 0
         </div>        


### PR DESCRIPTION
The number of transactions input erroneously said "days" instead of "transactions" which was causing confusion.