### PR TITLE
fix(token-claim): incorrect order of method for steemconnect

### DIFF
--- a/scripts/SE.js
+++ b/scripts/SE.js
@@ -472,7 +472,7 @@ SE = {
 				}
       });
     } else {
-			SE.SteemConnectJsonId('posting', claimData, 'scot_claim_token', () => {
+			SE.SteemConnectJsonId('posting', 'scot_claim_token', claimData, () => {
 				SE.HideLoading();
 			});
 		}


### PR DESCRIPTION
The ID is the second parameter, data was being supplied as the second parameter which was breaking things.