### PR TITLE
fix(wallet): balance check should account for sub < 1 and > 0 values

### DIFF
--- a/views/balances.html
+++ b/views/balances.html
@@ -46,7 +46,7 @@
 			<i class="fas fa-exchange-alt" title="Token market" onclick="SE.ShowMarket('${value}');"></i>&nbsp;&nbsp;&nbsp;
 			<i class="fas fa-share-square" title="Send tokens" onclick="SE.ShowSendTokenDialog('${value}', ${rowdata.balance});"></i>&nbsp;&nbsp;&nbsp; 
 			<i class="fas fa-list-ul" title="Show token history" onclick="SE.ShowHistory('${value}', '${rowdata.name}')"></i>
-			${token.stakingEnabled && rowdata.balance >= 1 ? `&nbsp;&nbsp;&nbsp;<i class="fas fa-lock" title="Stake Tokens" onclick="SE.ShowStakeDialog('${value}', ${rowdata.balance})"></i>` : ``}
+			${token.stakingEnabled && rowdata.balance > 0 ? `&nbsp;&nbsp;&nbsp;<i class="fas fa-lock" title="Stake Tokens" onclick="SE.ShowStakeDialog('${value}', ${rowdata.balance})"></i>` : ``}
 			${token.stakingEnabled && rowdata.stake ? `&nbsp;&nbsp;&nbsp;<i class="fas fa-unlock" title="Unstake Tokens" onclick="SE.ShowUnstakeDialog('${value}', ${rowdata.stake})"></i>` : ``}
 			${token.issuer === SE.User.name && !token.stakingEnabled ? `&nbsp;&nbsp;&nbsp;<i class="fas fa-gem" title="Enable Staking" onclick="SE.ShowEnableStakeDialog('${value}')"></i>` : ''}
 			${rowdata.pendingUnstake ? `&nbsp;&nbsp;&nbsp;<i class="fas fa-eye" onclick="SE.ShowHomeView('pending_unstakes')"></i>` : ``}


### PR DESCRIPTION
The previous check assumed a whole balance amount, but in some instances balances can be a decimal less than 1 amount still greater than 0.