### PR TITLE
Header style (mobile)

### DIFF
--- a/styles/mobile.css
+++ b/styles/mobile.css
@@ -30,6 +30,22 @@
     padding-right: 0;
     width: 100%;
   }
+  header .buttons {
+    display: block !important; 
+  }
+  header .buttons .btn {
+    font-size: 16px;
+    margin-top: 5px;
+  }
+  header .header-row {
+    padding-top: 20px;
+  }
+  header h1 {
+    font-size: 24px;
+  }
+  header p {
+    font-size: 16px;
+  }
   .faq-section-title {
     margin-left: 0;
   }

--- a/views/balances.html
+++ b/views/balances.html
@@ -35,7 +35,7 @@
 	</div>
 </header>
 
-<div class="container">
+<div class="container" style="overflow-x: scroll;">
   <table id="balances_table" class="tokensTable <%= data.account == SE.User.name ? 'interactiveTable' : '' %>" data-sorting="true"></table>
 </div>
 


### PR DESCRIPTION
Again not perfect but usable.

Before:
![image](https://user-images.githubusercontent.com/6792578/59469791-18628a00-8e36-11e9-9291-26c041e293cc.png)
![image](https://user-images.githubusercontent.com/6792578/59469827-362fef00-8e36-11e9-880c-2f16e4d6b1de.png)
![image](https://user-images.githubusercontent.com/6792578/59469874-4fd13680-8e36-11e9-9a2c-5dadfe7c2add.png)

After:
![se-1](https://user-images.githubusercontent.com/6792578/59469700-ddf8ed00-8e35-11e9-82bc-d429785e438c.png)
![se-2](https://user-images.githubusercontent.com/6792578/59469707-e18c7400-8e35-11e9-8387-6712e94deec6.png)
![se-3](https://user-images.githubusercontent.com/6792578/59469708-e18c7400-8e35-11e9-916d-15c883377349.png)

And the table on the balances page is now also scrollable.