### PR TITLE
Force active key signing for steemconnect links

### DIFF
--- a/scripts/SE.js
+++ b/scripts/SE.js
@@ -1584,6 +1584,7 @@ SE = {
 		if(auth_type == 'active') {
 			url += 'required_posting_auths=' + encodeURI('[]');
 			url += '&required_auths=' + encodeURI('["' + username + '"]');
+			url += '&authority=active';
 		} else
 			url += 'required_posting_auths=' + encodeURI('["' + username + '"]');
 
@@ -1604,6 +1605,7 @@ SE = {
 		if (auth_type == 'active') {
 			url += 'required_posting_auths=' + encodeURI('[]');
 			url += '&required_auths=' + encodeURI('["' + username + '"]');
+			url += '&authority=active';
 		} else {
 			url += 'required_posting_auths=' + encodeURI('["' + username + '"]');
 		}


### PR DESCRIPTION
Adding the param "&authority=active" on steemconnect links to force usage of active key (works on latest version of SC only).

Without this parameter the link will be broken on steemconnect latest version.