### PR TITLE
Urgent: Preserve 3 decimal places without rounding up

### DIFF
--- a/scripts/SE.js
+++ b/scripts/SE.js
@@ -1465,7 +1465,7 @@ SE = {
     };
 
     if(useKeychain()) {
-      steem_keychain.requestTransfer(SE.User.name, 'steemsc', formatSteemAmount(amount), JSON.stringify(transaction_data), 'STEEM', function(response) {
+      steem_keychain.requestTransfer(SE.User.name, 'steemsc', (amount).toFixedNoRounding(3), JSON.stringify(transaction_data), 'STEEM', function(response) {
         if(response.success && response.result) {
 					SE.CheckTransaction(response.result.id, 3, tx => {
 						if(tx.success) {
@@ -1482,7 +1482,7 @@ SE = {
       });
     } else {
 			SE.HideLoading();
-			SE.SteemConnectTransfer(SE.User.name, 'steemsc', formatSteemAmount(amount) + ' STEEM', JSON.stringify(transaction_data), () => {
+			SE.SteemConnectTransfer(SE.User.name, 'steemsc', (amount).toFixedNoRounding(3) + ' STEEM', JSON.stringify(transaction_data), () => {
 				SE.LoadBalances(SE.User.name, () => SE.ShowHistory(Config.NATIVE_TOKEN, 'Steem Engine Tokens'));
 			});
 		}
@@ -1506,7 +1506,7 @@ SE = {
     };
 
     if(useKeychain()) {
-      steem_keychain.requestTransfer(SE.User.name, Config.STEEMP_ACCOUNT, formatSteemAmount(amount), JSON.stringify(transaction_data), 'STEEM', function(response) {
+      steem_keychain.requestTransfer(SE.User.name, Config.STEEMP_ACCOUNT, (amount).toFixedNoRounding(3), JSON.stringify(transaction_data), 'STEEM', function(response) {
         if(response.success && response.result) {
 					SE.CheckTransaction(response.result.id, 3, tx => {
 						if(tx.success) {
@@ -1523,7 +1523,7 @@ SE = {
       });
     } else {
 			SE.HideLoading();
-			SE.SteemConnectTransfer(SE.User.name, Config.STEEMP_ACCOUNT, formatSteemAmount(amount) + ' STEEM', JSON.stringify(transaction_data), () => {
+			SE.SteemConnectTransfer(SE.User.name, Config.STEEMP_ACCOUNT, (amount).toFixedNoRounding(3) + ' STEEM', JSON.stringify(transaction_data), () => {
 				SE.LoadBalances(SE.User.name, () => SE.ShowMarket());
 			});
 		}
@@ -1541,7 +1541,7 @@ SE = {
 			"contractName": "steempegged",
 			"contractAction": "withdraw",
 			"contractPayload": { 
-				"quantity": formatSteemAmount(amount)
+				"quantity": (amount).toFixedNoRounding(3)
 			}
 		};
 

--- a/scripts/utils.js
+++ b/scripts/utils.js
@@ -132,7 +132,15 @@ function xss(text) {
   return text;
 }
 
-function formatSteemAmount(num) {
-  return num.toFixed(3).toString().match(/^-?\d+(?:\.\d{0,3})?/)[0];
-}
-
+// Ref: https://helloacm.com/javascripts-tofixed-implementation-without-rounding/
+// make 3 digits without rounding e.g. 3.1499 => 3.149 and 3.1 => 3.100
+Number.prototype.toFixedNoRounding = function(n) {
+    const reg = new RegExp("^-?\\d+(?:\\.\\d{0," + n + "})?", "g")
+    const a = this.toString().match(reg)[0];
+    const dot = a.indexOf(".");
+    if (dot === -1) { // integer, insert decimal dot and pad up zeros
+        return a + "." + "0".repeat(n);
+    }
+    const b = n - (a.length - dot) + 1;
+    return b > 0 ? (a + "0".repeat(b)) : a;
+ }


### PR DESCRIPTION
Regarding to PR: https://github.com/MattyIce/steem-engine/pull/68/files
The function *formatSteemAmount* will not have 3 decimal places for input values less than 3 decimal places. For example, *formatSteemAmount(3.1)* will return "3.1"

![image](https://user-images.githubusercontent.com/1764434/60290864-954f3280-9911-11e9-951e-d5be0978b86f.png)

This will be a problem for steem-js as it is expecting exactly 3 digits.

Therefore, I have made a function that does exactly this purpose: preserve 3 decimal places without rounding: see my blog:  https://helloacm.com/javascripts-tofixed-implementation-without-rounding/






